### PR TITLE
Check for Typescript errors

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,5 +14,7 @@ jobs:
         run: npm ci
       - name: Lint
         run: npm run lint
+      - name: Type checking
+        run: npm run tsc
       - name: Test
         run: npm run test -- --coverage

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test": "jest",
     "lint": "eslint src/",
     "build": "rm -rf ./dist && rollup -c --bundleConfigAsCjs",
+    "tsc": "tsc -p tsconfig-check.json",
     "build-pages": "rm -rf ./dist && parcel build index.html --public-url ./",
     "watch": "rollup -c -w --bundleConfigAsCjs",
     "serve": "parcel index.html",

--- a/tsconfig-check.json
+++ b/tsconfig-check.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "noEmit": true,
+    "emitDeclarationOnly": false,
+  }
+}


### PR DESCRIPTION
We're currently not doing any Typescript checks (except locally). This PR adds TS checking during the linting step. 