### PR TITLE
Allow publishing (beta) code without creating a release

### DIFF
--- a/.github/workflows/publish_demo.yml
+++ b/.github/workflows/publish_demo.yml
@@ -2,8 +2,6 @@ name: Publish to pages
 on:
   release:
     types: [created]
-    tags-ignore:        
-    - '**beta**'
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish_npm.yml
+++ b/.github/workflows/publish_npm.yml
@@ -1,7 +1,8 @@
 name: Publish to NPM
 on:
-  release:
-    types: [created]
+  push:
+    tags:
+      - '*'
 jobs:
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Made some minor changes here so we don't have to create a release for publishing beta code. This allows us to keep the releases overview clean. 