### PR TITLE
Export Orientation as string literal

### DIFF
--- a/src/Components/Controls/NextButton.tsx
+++ b/src/Components/Controls/NextButton.tsx
@@ -6,7 +6,7 @@ import './Button.scss';
 interface Props {
     onClick: () => void;
     isHidden: boolean;
-    direction: Orientation;
+    direction: `${Orientation}`;
 }
 
 export const NextButton: React.FC<Props> = ({ onClick, isHidden, direction }) => {

--- a/src/Components/Controls/PreviousButton.tsx
+++ b/src/Components/Controls/PreviousButton.tsx
@@ -6,7 +6,7 @@ import './Button.scss';
 interface Props {
     onClick: () => void;
     isHidden: boolean;
-    direction: Orientation;
+    direction: `${Orientation}`;
 }
 
 export const PreviousButton: React.FC<Props> = ({ onClick, isHidden, direction }) => {

--- a/src/Slider.tsx
+++ b/src/Slider.tsx
@@ -31,7 +31,7 @@ interface Settings {
     hideNavigationButtons?: boolean;
     initialSlideIndex?: number;
     onSlide?: () => void;
-    orientation?: Orientation,
+    orientation?: `${Orientation}`,
 }
 
 interface SlideVisibilityEntry {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
-import { Slider, Orientation } from './Slider';
+import { Slider } from './Slider';
 import type { SliderTypes } from './Slider';
 
-export { Slider, Orientation };
+export { Slider };
 export type { SliderTypes };


### PR DESCRIPTION
This way the Orientation doesn't have to be imported and string literals can be used. The syntax is a bit weird, but `${Orientation}` boils down to: any value of the Orientation ENUM. 