### PR TITLE
Expose functions for scrolling to next and previous slides

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ export default function YourComponent() {
 | getFirstFullyVisibleSlideIndex | `function` | `number` | Retrieve the first fully visible slide index |
 | getLastFullyVisibleSlideIndex  | `function` | `number` | Retrieve the last fully visible slide index  |
 | scrollToSlide                  | `function` | `void`   | Scroll the slider to a specific slide        |
+| scrollToNextSlide              | `function` | `void`   | Scroll the slider to the next slide          |
+| scrollToPreviousSlide          | `function` | `void`   | Scroll the slider to the previous slide      |
 
 #### Example on how to access the slider API:
 

--- a/src/Slider.test.tsx
+++ b/src/Slider.test.tsx
@@ -430,6 +430,78 @@ describe('Slider', () => {
             });
         });
 
+        it('scrolls to the previous slide programmatically', async () => {
+            const ref = React.createRef<SliderTypes.API>();
+
+            render(<Slider ref={ref}>
+                <span key={1}/>
+                <span key={2}/>
+                <span key={3}/>
+                <span key={4}/>
+            </Slider>);
+
+            const intersectionObserverInstance = getIntersectionObserverInstance();
+            const [intersectionCallback] = intersectionObserverInstance;
+            const slides = screen.getAllByRole('listitem');
+
+            slides.forEach((child, i) => {
+                Object.defineProperty(child, 'clientWidth', { configurable: true, value: 500 });
+                Object.defineProperty(child, 'offsetLeft', { value: 500 * (i + 1) });
+            });
+
+            act(() => {
+                intersectionCallback([
+                    { intersectionRatio: 0, target: slides[0] } as unknown as IntersectionObserverEntry,
+                    { intersectionRatio: 0, target: slides[1] } as unknown as IntersectionObserverEntry,
+                    { intersectionRatio: 1, target: slides[2] } as unknown as IntersectionObserverEntry,
+                    { intersectionRatio: 0.5, target: slides[3] } as unknown as IntersectionObserverEntry,
+                ], mockIntersectionObserver.mock.instances[0]);
+            });
+
+            act(() => {
+                if (ref.current !== null) {
+                    ref.current.scrollToPreviousSlide();
+                }
+            });
+
+            await waitFor(() => {
+                expect(scrollToSpy).toHaveBeenCalledWith({
+                    behavior: 'smooth',
+                    left: 1500,
+                });
+            });
+        });
+
+        it('scrolls to the next slide programmatically', async () => {
+            const ref = React.createRef<SliderTypes.API>();
+            render(<Slider ref={ref}>
+                <span key={1}/>
+                <span key={2}/>
+                <span key={3}/>
+                <span key={4}/>
+            </Slider>);
+
+            const slides = screen.getAllByRole('listitem');
+
+            slides.forEach((child, i) => {
+                Object.defineProperty(child, 'clientWidth', { configurable: true, value: 500 });
+                Object.defineProperty(child, 'offsetLeft', { value: 500 * (i + 1) });
+            });
+
+            act(() => {
+                if (ref.current !== null) {
+                    ref.current.scrollToNextSlide();
+                }
+            });
+
+            await waitFor(() => {
+                expect(scrollToSpy).toHaveBeenCalledWith({
+                    behavior: 'smooth',
+                    left: 500,
+                });
+            });
+        });
+
         it('scrolls to a specific slide', async () => {
             const ref = React.createRef<SliderTypes.API>();
             render(<Slider ref={ref}>

--- a/src/Slider.tsx
+++ b/src/Slider.tsx
@@ -18,6 +18,8 @@ import './Slider.scss';
 export namespace SliderTypes {
     export interface API {
         scrollToSlide: (index: number, behaviour: ScrollBehavior) => void;
+        scrollToNextSlide: () => void;
+        scrollToPreviousSlide: () => void;
         getFirstFullyVisibleSlideIndex(): number;
         getLastFullyVisibleSlideIndex(): number;
     }
@@ -315,6 +317,8 @@ export const Slider = forwardRef<SliderTypes.API, PropsWithChildren<Settings>>((
 
     useImperativeHandle(ref, () => ({
         scrollToSlide: scrollToSlide,
+        scrollToNextSlide: () => navigate(NavigationDirection.NEXT),
+        scrollToPreviousSlide: () => navigate(NavigationDirection.PREV),
         getFirstFullyVisibleSlideIndex: getFirstVisibleSlideIndex,
         getLastFullyVisibleSlideIndex: getLastVisibleSlideIndex,
     }));

--- a/src/Slider.tsx
+++ b/src/Slider.tsx
@@ -315,10 +315,13 @@ export const Slider = forwardRef<SliderTypes.API, PropsWithChildren<Settings>>((
         onSlide,
     ]);
 
+    const scrollToNextSlide = () => navigate(NavigationDirection.NEXT);
+    const scrollToPreviousSlide = () => navigate(NavigationDirection.PREV);
+
     useImperativeHandle(ref, () => ({
         scrollToSlide: scrollToSlide,
-        scrollToNextSlide: () => navigate(NavigationDirection.NEXT),
-        scrollToPreviousSlide: () => navigate(NavigationDirection.PREV),
+        scrollToNextSlide: scrollToNextSlide,
+        scrollToPreviousSlide: scrollToPreviousSlide,
         getFirstFullyVisibleSlideIndex: getFirstVisibleSlideIndex,
         getLastFullyVisibleSlideIndex: getLastVisibleSlideIndex,
     }));
@@ -345,8 +348,8 @@ export const Slider = forwardRef<SliderTypes.API, PropsWithChildren<Settings>>((
             </div>
             { !hideNavigationButtons && (
                 <>
-                    <PreviousButton onClick={() => navigate(NavigationDirection.PREV)} isHidden={!prevArrowVisible} direction={orientation}/>
-                    <NextButton onClick={() => navigate(NavigationDirection.NEXT)} isHidden={!nextArrowVisible} direction={orientation}/>
+                    <PreviousButton onClick={scrollToPreviousSlide} isHidden={!prevArrowVisible} direction={orientation}/>
+                    <NextButton onClick={scrollToNextSlide} isHidden={!nextArrowVisible} direction={orientation}/>
                 </>
             )}
         </div>


### PR DESCRIPTION
This will make it easier to develop features that rely on progressing the slider programmatically. For example, progressing the slider after an interval, implementing custom next/prev buttons, etc. 