### PR TITLE
Check whether the Slider is scrollable when adding a new slide

### DIFF
--- a/src/Slider.tsx
+++ b/src/Slider.tsx
@@ -108,7 +108,7 @@ export const Slider = forwardRef<SliderTypes.API, PropsWithChildren<Settings>>((
 
     const mouseMoveHandler = (event: ReactMouseEvent<HTMLDivElement>) => {
         const currentWrapper = wrapper.current;
-        const currentMousePos = mousePosition.current;
+        const currentMousePosition = mousePosition.current;
 
         if (!currentWrapper || !isDragging) {
             return;
@@ -116,18 +116,18 @@ export const Slider = forwardRef<SliderTypes.API, PropsWithChildren<Settings>>((
 
         switch (orientation) {
             case Orientation.HORIZONTAL:
-                if (shouldBlockClicks(currentMousePos.clientX - event.clientX)) {
+                if (shouldBlockClicks(currentMousePosition.clientX - event.clientX)) {
                     setIsBlockingClicks(true);
                 }
 
-                currentWrapper.scrollLeft = currentMousePos.scrollX + currentMousePos.clientX - event.clientX;
+                currentWrapper.scrollLeft = currentMousePosition.scrollX + currentMousePosition.clientX - event.clientX;
                 break;
             case Orientation.VERTICAL:
-                if (shouldBlockClicks(currentMousePos.clientY - event.clientY)) {
+                if (shouldBlockClicks(currentMousePosition.clientY - event.clientY)) {
                     setIsBlockingClicks(true);
                 }
 
-                currentWrapper.scrollTop = currentMousePos.scrollY + currentMousePos.clientY - event.clientY;
+                currentWrapper.scrollTop = currentMousePosition.scrollY + currentMousePosition.clientY - event.clientY;
                 break;
         }
     };

--- a/src/Slider.tsx
+++ b/src/Slider.tsx
@@ -58,7 +58,7 @@ export const Slider = forwardRef<SliderTypes.API, PropsWithChildren<Settings>>((
     const [isDragging, setIsDragging] = useState<boolean>(false);
     const [isBlockingClicks, setIsBlockingClicks] = useState<boolean>(false);
 
-    const [mousePosition, setMousePosition] = useState<{
+    const mousePosition = useRef<{
         clientX: number;
         clientY: number
         scrollX: number;
@@ -95,19 +95,20 @@ export const Slider = forwardRef<SliderTypes.API, PropsWithChildren<Settings>>((
     const mouseUpHandler = () => setIsDragging(false);
 
     const mouseDownHandler = (event: ReactMouseEvent<HTMLDivElement>) => {
-        setMousePosition({
+        mousePosition.current = {
             ...mousePosition,
             clientX: event.clientX,
             clientY: event.clientY,
             scrollX: wrapper.current?.scrollLeft ?? 0,
             scrollY: wrapper.current?.scrollTop ?? 0,
-        });
+        };
 
         setIsDragging(true);
     };
 
     const mouseMoveHandler = (event: ReactMouseEvent<HTMLDivElement>) => {
         const currentWrapper = wrapper.current;
+        const currentMousePos = mousePosition.current;
 
         if (!currentWrapper || !isDragging) {
             return;
@@ -115,18 +116,18 @@ export const Slider = forwardRef<SliderTypes.API, PropsWithChildren<Settings>>((
 
         switch (orientation) {
             case Orientation.HORIZONTAL:
-                if (shouldBlockClicks(mousePosition.clientX - event.clientX)) {
+                if (shouldBlockClicks(currentMousePos.clientX - event.clientX)) {
                     setIsBlockingClicks(true);
                 }
 
-                currentWrapper.scrollLeft = mousePosition.scrollX + mousePosition.clientX - event.clientX;
+                currentWrapper.scrollLeft = currentMousePos.scrollX + currentMousePos.clientX - event.clientX;
                 break;
             case Orientation.VERTICAL:
-                if (shouldBlockClicks(mousePosition.clientY - event.clientY)) {
+                if (shouldBlockClicks(currentMousePos.clientY - event.clientY)) {
                     setIsBlockingClicks(true);
                 }
 
-                currentWrapper.scrollTop = mousePosition.scrollY + mousePosition.clientY - event.clientY;
+                currentWrapper.scrollTop = currentMousePos.scrollY + currentMousePos.clientY - event.clientY;
                 break;
         }
     };

--- a/src/Slider.tsx
+++ b/src/Slider.tsx
@@ -223,42 +223,35 @@ export const Slider = forwardRef<SliderTypes.API, PropsWithChildren<Settings>>((
     useEffect(() => {
         const currentWrapper = wrapper.current;
 
-        if (!currentWrapper) {
-            return () => {};
+        if (!currentWrapper || !initialSlideIndex) {
+            return;
         }
 
-        const scrollToInitialSlide = () => {
-            if (initialSlideIndex !== 0) {
-                const targetSlide = slides.current[initialSlideIndex];
+        const targetSlide = slides.current[initialSlideIndex];
 
-                if (!targetSlide || !currentWrapper) {
-                    return;
-                }
+        if (!targetSlide) {
+            return;
+        }
 
-                let scrollLeft = undefined;
-                let scrollTop = undefined;
+        let scrollLeft = undefined;
+        let scrollTop = undefined;
 
-                switch (orientation) {
-                    case Orientation.HORIZONTAL:
-                        scrollLeft = targetSlide.element.offsetLeft - currentWrapper.offsetLeft;
-                        break;
-                    case Orientation.VERTICAL:
-                        scrollTop = targetSlide.element.offsetTop - currentWrapper.offsetTop;
-                        break;
-                }
+        switch (orientation) {
+            case Orientation.HORIZONTAL:
+                scrollLeft = targetSlide.element.offsetLeft - currentWrapper.offsetLeft;
+                break;
+            case Orientation.VERTICAL:
+                scrollTop = targetSlide.element.offsetTop - currentWrapper.offsetTop;
+                break;
+        }
 
-                const scrollOptions: Partial<ScrollToOptions> = {
-                    behavior: 'instant',
-                    ...(Number.isInteger(scrollLeft) && { left: scrollLeft } ),
-                    ...(Number.isInteger(scrollTop) && { top: scrollTop } ),
-                };
-
-                currentWrapper.scrollTo(scrollOptions);
-            }
+        const scrollOptions: Partial<ScrollToOptions> = {
+            behavior: 'instant',
+            ...(Number.isInteger(scrollLeft) && { left: scrollLeft } ),
+            ...(Number.isInteger(scrollTop) && { top: scrollTop } ),
         };
 
-
-        scrollToInitialSlide();
+        currentWrapper.scrollTo(scrollOptions);
 
     }, [wrapper, initialSlideIndex, orientation]);
 


### PR DESCRIPTION
Currently, the slider will not update it's controls if a slide is dynamically added and no resize of the window takes place. This changes will force a check whenever a slide gets added, to check if the Slider is scrollable. It's not the most efficient solution, but I don't expect any real performance impact. 

While developing this, I noticed a lot of re-render when using drag to scroll, since the mouse position was kept in the state. I've changed this to use a ref now, which reduced the amount of re-renders when dragging drastically. 