### PR TITLE
Do not render controls if both are hidden

### DIFF
--- a/src/Slider.test.tsx
+++ b/src/Slider.test.tsx
@@ -148,6 +148,13 @@ describe('Slider', () => {
     });
 
     describe('controls', () => {
+        it('does not render controls if both are hidden',  () => {
+            renderSliderWithDimensions({});
+
+            const nextButton = screen.queryByLabelText('Next slide');
+            expect(nextButton).not.toBeInTheDocument();
+        });
+
         it('sets controls visibility initially', () => {
             renderSliderWithDimensions({});
 

--- a/src/Slider.test.tsx
+++ b/src/Slider.test.tsx
@@ -149,10 +149,22 @@ describe('Slider', () => {
 
     describe('controls', () => {
         it('does not render controls if both are hidden',  () => {
-            renderSliderWithDimensions({});
+            renderSliderWithDimensions({
+                clientWidth: 3000,
+            });
+
+            const intersectionObserverInstance = getIntersectionObserverInstance();
+            const [intersectionCallback] = intersectionObserverInstance;
+
+            act(() => {
+                intersectionCallback([], mockIntersectionObserver.mock.instances[0]);
+            });
 
             const nextButton = screen.queryByLabelText('Next slide');
+            const prevButton = screen.queryByLabelText('Previous slide');
+
             expect(nextButton).not.toBeInTheDocument();
+            expect(prevButton).not.toBeInTheDocument();
         });
 
         it('sets controls visibility initially', () => {

--- a/src/Slider.tsx
+++ b/src/Slider.tsx
@@ -203,10 +203,6 @@ export const Slider = forwardRef<SliderTypes.API, PropsWithChildren<Settings>>((
         }
     }, [getFirstVisibleSlideIndex, getLastVisibleSlideIndex, isScrollable]);
 
-    useEffect(() => {
-
-    }, []);
-
     const checkScrollable = useCallback(() => {
         const currentWrapper = wrapper.current;
 

--- a/src/Slider.tsx
+++ b/src/Slider.tsx
@@ -57,6 +57,7 @@ export const Slider = forwardRef<SliderTypes.API, PropsWithChildren<Settings>>((
     const [isScrollable, setIsScrollable] = useState<boolean>(false);
     const [isDragging, setIsDragging] = useState<boolean>(false);
     const [isBlockingClicks, setIsBlockingClicks] = useState<boolean>(false);
+    const [showNavigationButtons, setShowNavigationButtons] = useState<boolean>(!hideNavigationButtons);
 
     const mousePosition = useRef<{
         clientX: number;
@@ -190,10 +191,21 @@ export const Slider = forwardRef<SliderTypes.API, PropsWithChildren<Settings>>((
 
     const setControlsVisibility = useCallback(() => {
         const lastSlideFullyVisible = getLastVisibleSlideIndex() + 1 === slides.current.length;
+        const isPrevArrowVisible = getFirstVisibleSlideIndex() > 0 && isScrollable;
+        const isNextArrowVisible = isScrollable && !lastSlideFullyVisible;
 
-        setPrevArrowVisible(getFirstVisibleSlideIndex() > 0 && isScrollable);
-        setNextArrowVisible(isScrollable && !lastSlideFullyVisible);
+        if (!isPrevArrowVisible && !isNextArrowVisible) {
+            setShowNavigationButtons(false);
+        } else {
+            setPrevArrowVisible(isPrevArrowVisible);
+            setNextArrowVisible(isNextArrowVisible);
+            setShowNavigationButtons(true);
+        }
     }, [getFirstVisibleSlideIndex, getLastVisibleSlideIndex, isScrollable]);
+
+    useEffect(() => {
+
+    }, []);
 
     const checkScrollable = useCallback(() => {
         const currentWrapper = wrapper.current;
@@ -361,7 +373,7 @@ export const Slider = forwardRef<SliderTypes.API, PropsWithChildren<Settings>>((
                     </div>
                 ))}
             </div>
-            { !hideNavigationButtons && (
+            { showNavigationButtons && (
                 <>
                     <PreviousButton onClick={scrollToPreviousSlide} isHidden={!prevArrowVisible} direction={orientation}/>
                     <NextButton onClick={scrollToNextSlide} isHidden={!nextArrowVisible} direction={orientation}/>


### PR DESCRIPTION
When both controls are hidden they are still rendered in UI. By not rendering them will solve the UX issue that both buttons are disabled. 